### PR TITLE
Replace pygerrit with our own client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pycrypto>=2.6
-pygerrit
+paramiko
 PyYAML
 pbr>=0.5.21,<1.0
 

--- a/tests/etc/zoidberg2.yaml
+++ b/tests/etc/zoidberg2.yaml
@@ -1,0 +1,28 @@
+- gerrits:
+  - master:
+      host: localhost
+      key_filename: some/other/key
+      username: master_user
+      project-pattern: .*
+      events:
+      - type: ref-updated
+        action: zoidberg.SyncBranch
+        branch-pattern: ^master$
+        target: thirdparty
+      startup:
+      - action: zoidberg.SyncBranch
+        target: thirdparty
+        projects: [stuff]
+        branches: [master]
+  - thirdparty:
+      host: localhost
+      key_filename: some/other/key
+      username: thirdparty_user
+      project-pattern: .*
+      events:
+      - type: ref-updated
+        action: thirdpartyactions.AnExcellentAction
+        branch-pattern: ^master$
+        target: master
+
+- plugins: [tests.thirdpartyactions, tests.moreactions]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,51 @@
+from mock import Mock, patch
+import paramiko
+import threading
+import socket
+import StringIO
+import testtools
+from zoidberg import gerrit
+from zoidberg import stream
+
+
+class ClientTestCase(testtools.TestCase):
+    def test_queue_event(self):
+        """
+        When a JSON representation of an event is passed to
+        queue_event, a python object ends up in the queue.
+        """
+        client = gerrit.GerritClient()
+        json_event = '{"type": "orsm-event", "something": "value"}'
+        client.queue_event(json_event)
+        event = client.event_queue.get(timeout=0.1)
+        self.assertEqual('orsm-event', event.type)
+        self.assertEqual('value', event.something)
+
+    def test_stream_supplies_client_with_events(self):
+        """
+        When a stream runs, it should do the following:
+        * get the transport from the client
+        * open a new session from the transport
+        * read in new event data
+        * send that event data to the client
+        """
+        mock_transport = Mock()
+        mock_channel = Mock()
+        mock_event = Mock()
+        stream_data_io = StringIO.StringIO(
+            '{"type": "orsm-event", "something": "value"}')
+        client = Mock()
+
+        client.get_transport.side_effect = [mock_transport]
+        mock_transport.open_session.side_effect = [mock_channel]
+        mock_channel.exit_status_ready.side_effect = [False]
+        mock_channel.makefile.side_effect = [stream_data_io]
+        mock_event.is_set.side_effect = [True, False]
+
+        stream = gerrit.GerritEventStream(client)
+        stream._running = mock_event
+        stream.run()
+        mock_channel.exec_command.assert_called_once_with(
+            'gerrit stream-events')
+        client.queue_event.assert_called_once_with(
+            '{"type": "orsm-event", "something": "value"}')

--- a/zoidberg/configuration.py
+++ b/zoidberg/configuration.py
@@ -1,6 +1,6 @@
-from gerrit import GerritClient
 import logging
 import re
+from .gerrit import GerritClient
 
 
 class Configuration(object):
@@ -46,18 +46,11 @@ class Configuration(object):
 
             self.gerrits[name]['events'] = {}
 
-            # client connection details
-            username = self.gerrits[name].get('username')
-            host = self.gerrits[name].get('host')
-            key_filename = self.gerrits[name].get('key_filename')
-            name = self.gerrits[name].get('name')
-            port = self.gerrits[name].get('port', 29418)
             # this is the only time we construct a new GerritClient
             # the client does not have an active ssh connection at
-            # this point
-            self.gerrits[name]['client'] = GerritClient(
-                username=username, host=host, key_filename=key_filename,
-                port=port)
+            # this point. Connection details are supplied when
+            # zoidberg calls activate_ssh
+            self.gerrits[name]['client'] = GerritClient()
 
             # create a list of actions for each event type
             for event in gerrit[name]['events']:

--- a/zoidberg/gerrit.py
+++ b/zoidberg/gerrit.py
@@ -1,112 +1,78 @@
 import logging
 import paramiko
-from pygerrit.client import GerritClient as PyGerritClient
-from pygerrit.error import GerritError
-from pygerrit.ssh import (
-    GerritSSHCommandResult, GerritSSHClient as PyGerritSSHClient)
+from paramiko import SSHClient
 from paramiko.ssh_exception import SSHException
+from Queue import Empty, Queue
+from .parser import parse
+from .stream import GerritEventStream
 
 
-class GerritSSHClient(PyGerritSSHClient):
-    """Fixes unicode handling bug in pygerrit."""
-    def __init__(self, *args, **kwargs):
-        super(GerritSSHClient, self).__init__(*args, **kwargs)
-        self.set_missing_host_key_policy(paramiko.client.WarningPolicy())
+class GerritClient(SSHClient):
+    def __init__(self):
+        super(GerritClient, self).__init__()
+        self.failed_events = []
+        self.load_system_host_keys()
+        self.set_missing_host_key_policy(paramiko.WarningPolicy())
+        self.event_queue = Queue()
+        self.event_stream = None
 
-    def run_gerrit_command(self, command):
-        """ Run the given command.
+    def activate_ssh(self, hostname, username, port, key_filename):
+        # record connection details so equality works
+        self.port = port
+        self.hostname = hostname
+        self.username = username
+        self.key_filename = key_filename
 
-        Make sure we're connected to the remote server, and run `command`.
+        self.connect(
+            username=username, hostname=hostname, port=port,
+            key_filename=key_filename)
+        self.get_transport().set_keepalive(30)
+        self.event_stream = GerritEventStream(self)
+        self.event_stream.start()
 
-        Return the results as a `GerritSSHCommandResult`.
+    def store_failed_event(self, event):
+        """Stores an event so it can be queued later."""
+        self.failed_events.append(event)
 
-        Raise `ValueError` if `command` is not a string, or `GerritError` if
-        command execution fails.
+    def enqueue_failed_events(self):
+        for e in self.failed_events:
+            self.event_queue.put(e)
+        self.failed_events = []
 
-        """
+    def queue_event(self, data):
+        """converts the json to an object, puts it in the queue"""
+        event = parse(data)
+        self.event_queue.put(event)
+
+    def get_event(self, timeout):
+        try:
+            return self.event_queue.get(timeout=timeout)
+        except Empty:
+            pass
+
+    def is_active(self):
+        transport = self.get_transport()
+        return (
+            self.event_stream and self.event_stream.is_active() and
+            transport and transport.is_active())
+
+    def run_command(self, command):
         gerrit_command = "gerrit " + command
 
-        # fixes the unicode handling bug while we wait for 0.2.9 release
         try:
             gerrit_command.encode('ascii')
         except UnicodeEncodeError:
             gerrit_command = gerrit_command.encode('utf-8')
 
-        self._connect()
         try:
             stdin, stdout, stderr = self.exec_command(gerrit_command,
                                                       bufsize=1,
                                                       timeout=None,
                                                       get_pty=False)
         except SSHException as err:
-            raise GerritError("Command execution error: %s" % err)
-        return GerritSSHCommandResult(command, stdin, stdout, stderr)
+            logging.error("Command execution error: %s" % err)
+        return stdout.readlines()
 
-
-class GerritClient(PyGerritClient):
-    """Allows injecting of the key filename."""
-    def __init__(self, host, username, key_filename, port=29418):
-        super(GerritClient, self).__init__(
-            host=host, username=username, port=port)
-        # overwrite the pygerrit ssh client with our own that contains
-        # some fixes
-        self._ssh_client = GerritSSHClient(host, username=username, port=port)
-        self._ssh_client.key_filename = key_filename
-        self.failed_events = []
-        # At this point, we don't have an ssh connection active.
-        # That's handled by the event processing loop, which will
-        # try to activate ssh connections for a client that isn't
-        # connected.
-
-    def __eq__(self, other):
-        """Two clients are equal if they have the same connection details."""
-        return (
-            self._ssh_client.port == other._ssh_client.port
-            and
-            self._ssh_client.username == other._ssh_client.username
-            and
-            self._ssh_client.key_filename == other._ssh_client.key_filename
-            and
-            self._ssh_client.hostname == other._ssh_client.hostname)
-
-    def stop_event_stream(self):
-        """Stop streaming events from `gerrit stream-events`."""
-        if self._stream:
-            self._stream.stop()
-
-            # fix for bug where pygerrit's stop_event_stream would insist on
-            # one more event coming from the stream before it would shut down
-            # and we don't want to wait
-            self._ssh_client.close()
-
-            self._stream.join()
-            self._stream = None
-            with self._events.mutex:
-                self._events.queue.clear()
-
-    def activate_ssh(self, host, username, key_filename, port=29418):
-        """Activates the ssh connection."""
-        self._ssh_client._connect()
-        logging.info(
-            'Connected to %s, gerrit version %s'
-            % (host, self.gerrit_version()))
-
-    def is_active(self):
-        transport = self._ssh_client.get_transport()
-        if transport and transport.is_active():
-            return True
-        if transport:
-            # instead of checking the transport, pygerrit uses an Event
-            # but if a gerrit disconnects, the Event isn't updated,
-            # so we check the transport and update things nicely here.
-            self._ssh_client.connected.clear()
-        return False
-
-    def store_failed_event(self, event):
-        """Stores a GerritEvent object so it can be queued later."""
-        self.failed_events.append(event)
-
-    def enqueue_failed_events(self):
-        for e in self.failed_events:
-            self._events.put(e)
-        self.failed_events = []
+    def shutdown(self):
+        self.event_stream.stop()
+        self.close()

--- a/zoidberg/parser.py
+++ b/zoidberg/parser.py
@@ -1,0 +1,9 @@
+import json
+from collections import namedtuple
+
+
+def parse(data):
+    """Quick, easy, and quite dirty, JSON to object."""
+    return json.loads(
+        data, object_hook=lambda d: namedtuple(
+            'ParsedJsonObject', d.keys())(*d.values()))

--- a/zoidberg/stream.py
+++ b/zoidberg/stream.py
@@ -1,0 +1,49 @@
+import logging
+from threading import Thread, Event
+
+
+class GerritEventStream(Thread):
+    """
+    Connects to gerrit's stream-events output and queues incoming
+    data in the client.
+    """
+    def __init__(self, client):
+        super(GerritEventStream, self).__init__()
+        self._client = client
+        self.daemon = True
+        self._channel = None
+        self._running = Event()
+
+    def _stop_with_error(self, error_message):
+        logging.error(error_message)
+        self.stop()
+
+    def is_active(self):
+        return self._running.is_set()
+
+    def run(self):
+        self._running.set()
+        self._channel = self._client.get_transport().open_session()
+        self._channel.exec_command('gerrit stream-events')
+
+        stdout = self._channel.makefile()
+        stderr = self._channel.makefile_stderr()
+
+        while self._running.is_set():
+            try:
+                if self._channel.exit_status_ready():
+                    if self._channel.recv_stderr_ready():
+                        error = stderr.readline().strip()
+                    else:
+                        error = "Remote server connection closed"
+                    self._stop_with_error(error)
+                else:
+                    data = stdout.readline()
+                    self._client.queue_event(data)
+            except Exception as e:  # pylint: disable=W0703
+                self._stop_with_error(repr(e))
+
+    def stop(self):
+        self._running.clear()
+        if self._channel:
+            self._channel.close()


### PR DESCRIPTION
Instead of messing around with pygerrit internals to
make sure that client connections and streaming
threads start and stop together properly, this
change implements our own client.

This wraps the stream thread inside the gerrit client,
so that we're not trying to deal with them separately.

There are other bug fixes:
- Keepalive connections by default
- Client persistence when reloading configuration fixed
- Simple JSON->object parser
- Actions changed to refer to the properties as named
  by the JSON supplied by gerrit
- Errors while running actions are logged and do not
  cause zoidberg to exit
